### PR TITLE
use import instead of require

### DIFF
--- a/resources/js/login-as-customer.js
+++ b/resources/js/login-as-customer.js
@@ -1,1 +1,1 @@
-Vue.component('login-as-customer', require('./components/LoginAsCustomer.vue').default)
+Vue.component('login-as-customer', () => import('./components/LoginAsCustomer.vue'))


### PR DESCRIPTION
Both Webpack and Vite support import functions, so this is a backwards compatible change