### PR TITLE
[2.x] Fix existing guest cart causing error

### DIFF
--- a/resources/js/components/LoginAsCustomer.vue
+++ b/resources/js/components/LoginAsCustomer.vue
@@ -1,6 +1,6 @@
 <script>
 import { token } from 'Vendor/rapidez/core/resources/js/stores/useUser'
-import { refresh as refreshCart } from 'Vendor/rapidez/core/resources/js/stores/useCart'
+import { fetchCustomerCart } from 'Vendor/rapidez/core/resources/js/stores/useCart'
 import InteractWithUser from 'Vendor/rapidez/core/resources/js/components/User/mixins/InteractWithUser'
 
 export default {
@@ -46,7 +46,7 @@ export default {
                 await this.refreshUser(false)
                 this.setCheckoutCredentialsFromDefaultUserAddresses()
                 await window.app.$emit('logged-in')
-                await refreshCart()
+                await fetchCustomerCart()
 
                 Turbo.visit(window.url('/account'))
             } catch (error) {


### PR DESCRIPTION
By using `refreshCart`, the cart mask does not get reset.

Thus, if you have an active guest cart when you use this, it will try to fetch said guest cart after having logged in. This gives a big fat unauthorized error, logging you out instantly.

Fortunately, the `fetchCustomerCart` function already exists in useCart.js so we can just swap it out.

I could also check for a mask and use `linkUserToCart` when appropriate like the login function does, but I feel like that's not a good idea for the use case of this package.