### PR TITLE
Support Magento Admin Ui login as customer

### DIFF
--- a/resources/js/components.js
+++ b/resources/js/components.js
@@ -1,3 +1,4 @@
 import 'Vendor/rapidez/core/resources/js/vue'
 
 Vue.component('login-as-customer', () => import('./components/LoginAsCustomer.vue'))
+Vue.component('login-as-customer-by-token', () => import('./components/LoginAsCustomerByToken.vue'))

--- a/resources/js/components/LoginAsCustomer.vue
+++ b/resources/js/components/LoginAsCustomer.vue
@@ -1,6 +1,5 @@
 <script>
-import { token } from 'Vendor/rapidez/core/resources/js/stores/useUser'
-import { fetchCustomerCart, refresh as refreshCustomer } from 'Vendor/rapidez/core/resources/js/stores/useCart'
+import { clear, loginByToken } from 'Vendor/rapidez/core/resources/js/stores/useUser'
 
 export default {
     render() {
@@ -16,6 +15,8 @@ export default {
     methods: {
         async login() {
             try {
+                const clearPromise = clear()
+
                 let adminResponse = await window.magentoAPI('post', 'integration/admin/token', {
                     username: this.username,
                     password: this.password,
@@ -32,10 +33,8 @@ export default {
                     return
                 }
 
-                token.value = tokenResponse.data.generateCustomerTokenAsAdmin.customer_token
-                await refreshCustomer()
-                await window.app.$emit('logged-in')
-                await fetchCustomerCart()
+                await clearPromise
+                await loginByToken(tokenResponse.data.generateCustomerTokenAsAdmin.customer_token)
 
                 Turbo.visit(window.url('/account'))
             } catch (error) {

--- a/resources/js/components/LoginAsCustomerByToken.vue
+++ b/resources/js/components/LoginAsCustomerByToken.vue
@@ -1,0 +1,39 @@
+<script>
+import { clear, loginByToken } from 'Vendor/rapidez/core/resources/js/stores/useUser'
+
+export default {
+    props: ['token'],
+
+    render() {
+        return this.$scopedSlots.default(this)
+    },
+
+    data: () => ({
+        processing: false,
+    }),
+
+    mounted() {
+        this.$nextTick(() => {
+            if (this.token) {
+                this.processing = true
+                this.login().finally(
+                    () => (this.processing = false),
+                )
+            }
+        })
+    },
+
+    methods: {
+        async login() {
+            try {
+                await clear()
+                await loginByToken(this.token)
+
+                Turbo.visit(window.url('/account'))
+            } catch (error) {
+                Notify(error.message, 'error')
+            }
+        }
+    },
+}
+</script>

--- a/resources/views/login-as-customer.blade.php
+++ b/resources/views/login-as-customer.blade.php
@@ -7,6 +7,16 @@
 @section('content')
     <div class="flex flex-col items-center">
         <h1 class="font-bold text-4xl mb-5">@lang('Login as customer')</h1>
+        @if($token ?? '') 
+            <login-as-customer-by-token token="{{ $token }}" v-slot="{ processing }">
+                <div v-cloak v-if="processing" class="bg-black bg-opacity-50 z-50 fixed inset-0 flex justify-items-center items-center">
+                    <div class="flex-row justify-items-center items-center mx-auto">
+                        <x-rapidez-loading class="size-10 text-gray-200 animate-spin fill-primary" />
+                        <span class="text-white">@lang('Logging in...')</span>
+                    </div>
+                </div>
+            </login-as-customer-by-token>
+        @endif
 
         <login-as-customer v-slot="login" v-cloak>
             <form class="p-8 border rounded w-[400px]" v-on:submit.prevent="login.login">

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Rapidez\LoginAsCustomer\Http\Controllers\GetSignedLoginAsCustomerController;
+
+Route::middleware('api')->prefix('api')->group(function () {
+    Route::post('get-login-as-customer-url', GetSignedLoginAsCustomerController::class);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Rapidez\LoginAsCustomer\Http\Controllers\SignedLoginAsCustomerController;
+
+Route::middleware('web')->group(function () {
+    Route::get('login-as-customer/signed', SignedLoginAsCustomerController::class)->name('signed-login-as-customer');
+    Route::view('login-as-customer', 'rapidez::login-as-customer')->name('login-as-customer');
+});

--- a/src/Http/Controllers/GetSignedLoginAsCustomerController.php
+++ b/src/Http/Controllers/GetSignedLoginAsCustomerController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rapidez\LoginAsCustomer\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+class GetSignedLoginAsCustomerController
+{
+    /**
+     * Time for the signed route to be valid for, 2 minutes will result in a timeout anyways.
+     * So it's better to remove the token after that time.
+     */
+    public const URL_TIMEOUT = 120;
+
+    public function __invoke(Request $request)
+    {
+        $data = $request->validate([
+            'token' => 'required',
+        ]);
+        $cachekey = (string) Str::uuid();
+        Cache::store(config('cache.default'))->put('login-as-customer-' . $cachekey, $data, static::URL_TIMEOUT);
+
+        return ['url' => URL::signedRoute('signed-login-as-customer', ['key' => $cachekey], static::URL_TIMEOUT)];
+    }
+}

--- a/src/Http/Controllers/SignedLoginAsCustomerController.php
+++ b/src/Http/Controllers/SignedLoginAsCustomerController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rapidez\LoginAsCustomer\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class SignedLoginAsCustomerController
+{
+    public function __invoke(Request $request)
+    {
+        $cache = Cache::store(config('cache.default'));
+        if (! $request->hasValidSignature() || ! $cache->has('login-as-customer-' . $request->get('key'))) {
+            return redirect()->route('login-as-customer');
+        }
+
+        $data = $cache->get('login-as-customer-' . $request->get('key'));
+        $cache->forget('login-as-customer-' . $request->get('key'));
+
+        if (! config('rapidez.models.customer')::whereToken($data['token'])->exists()) {
+            return redirect()->route('login-as-customer');
+        }
+
+        return view('rapidez::login-as-customer', ['token' => $data['token']]);
+    }
+}

--- a/src/LoginAsCustomerServiceProvider.php
+++ b/src/LoginAsCustomerServiceProvider.php
@@ -20,6 +20,14 @@ class LoginAsCustomerServiceProvider extends ServiceProvider
             __DIR__.'/../resources/views' => resource_path('views/vendor/rapidez'),
         ], 'views');
 
-        Route::view('login-as-customer', 'rapidez::login-as-customer');
+        $this->bootRoutes();
+    }
+
+    protected function bootRoutes(): self
+    {
+        $this->loadRoutesFrom(__DIR__ . '/../routes/api.php');
+        $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
+
+        return $this;
     }
 }


### PR DESCRIPTION
This allows Magento to communicate the customer token to Rapidez in a similar way as has been done in the Standalone checkout, securely passing the token.

This is used by: 