### PR TITLE
[4.x] Added support for subfolder multistore with signed routes

### DIFF
--- a/src/Http/Controllers/GetSignedLoginAsCustomerController.php
+++ b/src/Http/Controllers/GetSignedLoginAsCustomerController.php
@@ -23,6 +23,16 @@ class GetSignedLoginAsCustomerController
         $cachekey = (string) Str::uuid();
         Cache::store(config('cache.default'))->put('login-as-customer-' . $cachekey, $data, static::URL_TIMEOUT);
 
-        return ['url' => URL::signedRoute('signed-login-as-customer', ['key' => $cachekey], static::URL_TIMEOUT)];
+        $currentUrl = url('/');
+        $urlParts = parse_url($currentUrl);
+        try {
+            // Temporarily force root url without subfolder since validation runs without subfolder.
+            URL::forceRootUrl($urlParts['scheme'] . '://' . $urlParts['host'] . '/');
+            $signedUrl = URL::signedRoute('signed-login-as-customer', ['key' => $cachekey], static::URL_TIMEOUT, absolute: false);
+        } finally {
+            URL::forceRootUrl($currentUrl);
+        }
+    
+        return ['url' => url($signedUrl)];
     }
 }

--- a/src/Http/Controllers/SignedLoginAsCustomerController.php
+++ b/src/Http/Controllers/SignedLoginAsCustomerController.php
@@ -10,7 +10,7 @@ class SignedLoginAsCustomerController
     public function __invoke(Request $request)
     {
         $cache = Cache::store(config('cache.default'));
-        if (! $request->hasValidSignature(absolute: true) || ! $cache->has('login-as-customer-' . $request->get('key'))) {
+        if (! $request->hasValidSignature(absolute: false) || ! $cache->has('login-as-customer-' . $request->get('key'))) {
             return redirect()->route('login-as-customer');
         }
 

--- a/src/Http/Controllers/SignedLoginAsCustomerController.php
+++ b/src/Http/Controllers/SignedLoginAsCustomerController.php
@@ -10,7 +10,7 @@ class SignedLoginAsCustomerController
     public function __invoke(Request $request)
     {
         $cache = Cache::store(config('cache.default'));
-        if (! $request->hasValidSignature() || ! $cache->has('login-as-customer-' . $request->get('key'))) {
+        if (! $request->hasValidSignature(absolute: true) || ! $cache->has('login-as-customer-' . $request->get('key'))) {
             return redirect()->route('login-as-customer');
         }
 


### PR DESCRIPTION
With projects using subfolders for multistore signature validation would fail.
This is due to `URL::signedRoute` generating the key with the `forceRootUrl` in mind (thus having the e.g.: `/nl/`)
In the check if it is valid, `$request->path()` is used. Which does not contain `/nl/`

This changes that by checking relative paths and making sure multistore subfolders are not part of it's paths.
ref: GT-2413